### PR TITLE
Feature 1 service must greet in English

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,15 @@ To test the REST service use e.g. Postman:
      - Body:
             { "greeting": "Hallo!" }
 
+To test the REST service greeting in English:
+
+    GET http://localhost:8080/greetings
+    having set Accept-Language "en"
+
+    and get a response 200 OK back, with 
+     - Headers 
+          content-length: 21
+          content-type: application/json
+     - Body:
+            { "greeting": "Hello!" }
 

--- a/src/main/java/com/example/Greeting.java
+++ b/src/main/java/com/example/Greeting.java
@@ -1,5 +1,8 @@
 package com.example;
 
+import java.util.Arrays;
+
+import javax.validation.constraints.Pattern;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -11,17 +14,33 @@ import javax.ws.rs.core.MediaType;
  */
 @Path("greetings")
 public class Greeting {
-
+    
     /**
-     * Method handling HTTP GET requests. 
-     * 
+     * Method handling HTTP GET requests.
+     *
      * The returned object will be sent back as "application/json" media type.
-     * @param acceptLanguage client can set the preferred language(s) as in HTTP spec.
+     *
+     * @param acceptLanguage client can set the preferred preferredLanguage(s) as in HTTP spec.
      * @return String that will be returned containing "application/json".
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getGreeting(@HeaderParam("Accept-Language") String acceptLanguage) {
+    public String getGreeting(@HeaderParam("Accept-Language") 
+            @Pattern(regexp = "^((\\s*[a-z]{2},{0,1}(-{0,1}[a-z]{2}){0,1})+(;q=0\\.[1-9]){0,1},{0,1})+") 
+            String acceptLanguage) {
+        String language = preferredLanguage(acceptLanguage);
+        if (language.contains("en")) {
+            return "{\"greeting\":\"Hello!\"}";
+        }
         return "{\"greeting\":\"Hallo!\"}";
+    }
+
+    private String preferredLanguage(String preferred) {
+        if (preferred == null || preferred.isEmpty()) {
+            return "da";
+        }
+        String[] languages = preferred.split(",");
+        String[] preferredLanguage = Arrays.stream(languages).filter(s -> !s.contains(";")).toArray(String[]::new);
+        return preferredLanguage[0];
     }
 }

--- a/src/test/java/com/example/GreetingTest.java
+++ b/src/test/java/com/example/GreetingTest.java
@@ -33,4 +33,46 @@ public class GreetingTest {
         String responseMsg = target.path("greetings").request().get(String.class);
         assertEquals("{\"greeting\":\"Hallo!\"}", responseMsg);
     }
+
+    @Test
+    public void testGetNoFrenchGreeting() {
+        String responseMsg = target.path("greetings").request().acceptLanguage("fr").get(String.class);
+        assertEquals("{\"greeting\":\"Hallo!\"}", responseMsg);
+    }
+
+    @Test
+    public void testGetPreferredGreetingDanish() {
+        String responseMsg = target.path("greetings").request().acceptLanguage("da, en-gb;q=0.9, en;q=0.8, fr;q=0.5").get(String.class);
+        assertEquals("{\"greeting\":\"Hallo!\"}", responseMsg);
+    }
+
+    @Test
+    public void testGetPreferredGreetingEnglish() {
+        String responseMsg = target.path("greetings").request().acceptLanguage("en, da;q=0.9, en-gb;q=0.8, fr;q=0.5").get(String.class);
+        assertEquals("{\"greeting\":\"Hello!\"}", responseMsg);
+    }
+
+    @Test
+    public void testGetPreferredGreetingDanishEnglish() {
+        String responseMsg = target.path("greetings").request().acceptLanguage("da, en, da;q=0.9, en-gb;q=0.8, fr;q=0.5").get(String.class);
+        assertEquals("{\"greeting\":\"Hallo!\"}", responseMsg);
+    }
+
+    @Test
+    public void testGetPreferredGreetingEnglishDanish() {
+        String responseMsg = target.path("greetings").request().acceptLanguage("en, da, da;q=0.9, en-gb;q=0.8, fr;q=0.5").get(String.class);
+        assertEquals("{\"greeting\":\"Hello!\"}", responseMsg);
+    }
+
+    @Test
+    public void testGetEnglishGreeting() {
+        String responseMsg = target.path("greetings").request().acceptLanguage("en").get(String.class);
+        assertEquals("{\"greeting\":\"Hello!\"}", responseMsg);
+    }
+
+    @Test
+    public void testGetEnglishGreetingByBritish() {
+        String responseMsg = target.path("greetings").request().acceptLanguage("en-gb").get(String.class);
+        assertEquals("{\"greeting\":\"Hello!\"}", responseMsg);
+    }
 }


### PR DESCRIPTION
A simple implementation of language support was created based on Accept-Language header, which seems to be the natural way to handle this. The service still has the character of being very static and that is done to keep the service as simple as possible at this stage.